### PR TITLE
Fix input_general_update_mode copy-paste error

### DIFF
--- a/blueprints/automation/EdwardTFN/auto_update_scheduled.yaml
+++ b/blueprints/automation/EdwardTFN/auto_update_scheduled.yaml
@@ -287,7 +287,7 @@ action:
       input_schedule_monthday: !input schedule_monthday
       input_core_os_update_mode: !input core_os_update_mode
       input_firmware_update_mode: !input firmware_update_mode
-      input_general_update_mode: !input firmware_update_mode
+      input_general_update_mode: !input general_update_mode
       input_pause_entities: !input pause_entities
 
       core_update_entity: >-


### PR DESCRIPTION
Couldn't figure out why the blueprint wasn't working for me. Found this copy/paste error after digging into logs/the source.